### PR TITLE
Bugfix: Loaded waveform not displaying

### DIFF
--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/UIDataManager.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/UIDataManager.java
@@ -18,6 +18,7 @@ import wycliffeassociates.recordingapp.R;
 import wycliffeassociates.recordingapp.Recording.RecordingMessage;
 import wycliffeassociates.recordingapp.Recording.RecordingQueues;
 import wycliffeassociates.recordingapp.Recording.WavFileWriter;
+import wycliffeassociates.recordingapp.Reporting.Logger;
 import wycliffeassociates.recordingapp.WavFileLoader;
 
 /**
@@ -42,13 +43,15 @@ public class UIDataManager {
     private Animation anim;
     RecordingTimer timer;
     private final TextView timerView;
-    private boolean mode;
+    private boolean playbackOrRecording;
     private boolean isALoadedFile = false;
 
 
-    public UIDataManager(WaveformView mainWave, MinimapView minimap, Activity ctx, boolean mode, boolean isALoadedFile){
+    public UIDataManager(WaveformView mainWave, MinimapView minimap, Activity ctx, boolean playbackOrRecording, boolean isALoadedFile){
+        Logger.i(UIDataManager.class.toString(), "Is a loaded file: " + isALoadedFile);
         this.isALoadedFile = isALoadedFile;
-        this.mode = mode;
+        this.playbackOrRecording = playbackOrRecording;
+        Logger.i(UIDataManager.class.toString(), "Playback mode: " + playbackOrRecording);
         mainWave.setUIDataManager(this);
         minimap.setUIDataManager(this);
         this.mainWave = mainWave;
@@ -106,7 +109,7 @@ public class UIDataManager {
     }
 
     public void enablePlay(){
-        if(mode == PLAYBACK_MODE) {
+        if(playbackOrRecording == PLAYBACK_MODE) {
             ctx.findViewById(R.id.btnPause).setVisibility(View.INVISIBLE);
             ctx.findViewById(R.id.btnPlay).setVisibility(View.VISIBLE);
         }
@@ -177,20 +180,25 @@ public class UIDataManager {
     }
 
     public void loadWavFromFile(String path){
-
         wavLoader = new WavFileLoader(path, mainWave.getWidth(), isALoadedFile);
         buffer = wavLoader.getMappedFile();
         preprocessedBuffer = wavLoader.getMappedCacheFile();
         mappedAudioFile = wavLoader.getMappedAudioFile();
-        System.out.println("Mapped files completed.");
-//      System.out.println("Compressed file is size: " + preprocessedBuffer.capacity() + " Regular file is size: " + buffer.capacity() + " increment is " + (int)Math.floor((AudioInfo.SAMPLERATE * 5)/mainWave.getWidth()));
+        if(buffer == null){
+            Logger.e(UIDataManager.class.toString(), "Buffer is null.");
+        }
+        if(preprocessedBuffer == null){
+            Logger.w(UIDataManager.class.toString(), "Visualization buffer is null.");
+        }
+        Logger.i(UIDataManager.class.toString(), "MainWave height: " + mainWave.getHeight() + " width: " + mainWave.getWidth());
         minimap.init(wavLoader.getMinimap(minimap.getWidth(), minimap.getHeight()));
         WavPlayer.loadFile(getMappedAudioFile());
         minimap.setAudioLength(WavPlayer.getDuration());
-        System.out.println("There was an error with mapping the files");
         wavVis = new WavVisualizer(buffer, preprocessedBuffer, mainWave.getWidth(), mainWave.getHeight());
     }
-    //NOTE: Only one instance of canvas view can call this; otherwise two threads will be pulling from the same queue!!
+
+    //NOTE: software architecture will only allow one instance of this at a time, do not declare multiple
+    //canvas views to listen for recording on the same activity
     public void listenForRecording(boolean drawWaveform){
         mainWave.setDrawingFromBuffer(true);
         ctx.findViewById(R.id.volumeBar).setVisibility(View.VISIBLE);
@@ -242,7 +250,6 @@ public class UIDataManager {
                                     });
                                 }
                             }
-                            //changeVolumeBar(ctx, db);
                         }
                         if (isStopped) {
                             lock.acquire();
@@ -279,28 +286,15 @@ public class UIDataManager {
 
     public void drawWaveformDuringPlayback(int location){
         mainWave.setDrawingFromBuffer(false);
-        long startTime = System.nanoTime();
-        try {
-            lock.acquire();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        float[] samples = null;
         mainWave.setMarkerToDrawStart(CanvasView.getMarkerStartTime());
         mainWave.setMarkerToDrawEnd(CanvasView.getMarkerEndTime());
-        float[] samples = wavVis.getDataToDraw(location, WavFileWriter.largest);
-        lock.release();
+        //FIXME: 10000 works in general, was WavFileWriter.largest. which doesn't work when loading files
+        //Scaling should be based on db levels anyway?
+        samples = wavVis.getDataToDraw(location, 10000);
         mainWave.setIsDoneDrawing(false);
-        //System.out.println("Time taken to generate samples to draw: " + (System.nanoTime()-startTime));
-        //System.out.println("Size of buffer to draw is "+samples.size());
-        try {
-            lock.acquire();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
         mainWave.setWaveformDataForPlayback(samples);
-        lock.release();
         mainWave.postInvalidate();
-        Runtime.getRuntime().freeMemory();
     }
 
     private float[] convertToArray(ArrayList<Pair<Double,Double>> samples){

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/WavVisualizer.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/WavVisualizer.java
@@ -43,7 +43,6 @@ public class WavVisualizer {
         //based on the user scale, determine which buffer waveData should be
         useCompressedFile = shouldUseCompressedFile(numSecondsOnScreen);
         MappedByteBuffer waveData = selectBufferToUse(useCompressedFile);
-        System.out.println("use compressed file is " + useCompressedFile);
 
 
         //get the number of array indices to skip over- the array will likely contain more data than one pixel can show
@@ -151,7 +150,7 @@ public class WavVisualizer {
 
     private int computeSampleStartPosition(int startMillisecond, int numSecondsOnScreen){
         // multiplied by 2 because of a hi and low for each sample in the compressed file
-        System.out.println("Duration of file is " + WavPlayer.getDuration());
+        //System.out.println("Duration of file is " + WavPlayer.getDuration());
         int sampleStartPosition = (useCompressedFile)? AudioInfo.SIZE_OF_SHORT * 2 * (int)Math.floor((startMillisecond * ((numSecondsOnScreen*screenWidth)/(AudioInfo.COMPRESSED_SECONDS_ON_SCREEN)/(double)(numSecondsOnScreen*1000) )))
                 : (int)((startMillisecond/1000.0) * AudioInfo.SAMPLERATE ) * AudioInfo.SIZE_OF_SHORT;
         return sampleStartPosition;

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/WavFileLoader.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/WavFileLoader.java
@@ -11,6 +11,7 @@ import java.nio.channels.FileChannel;
 import wycliffeassociates.recordingapp.AudioVisualization.WavVisualizer;
 import wycliffeassociates.recordingapp.Playback.WavPlayer;
 import wycliffeassociates.recordingapp.Recording.WavFileWriter;
+import wycliffeassociates.recordingapp.Reporting.Logger;
 
 public class WavFileLoader {
 
@@ -73,12 +74,12 @@ public class WavFileLoader {
      * @param loadedFile whether or not the file was loaded or had just been recorded
      */
     public WavFileLoader(String file, int screenWidth, boolean loadedFile) {
-        System.out.println("creating a new file after a cut, file is " + file);
         loadedFilename = file;
         this.screenWidth = screenWidth;
         threadFinished = false;
         RandomAccessFile raf = null;
         try {
+            Logger.i(WavFileLoader.class.toString(), "Loading the file: " + file);
             raf = new RandomAccessFile(file, "r");
             FileChannel fc = raf.getChannel();
             buffer = fc.map(FileChannel.MapMode.READ_ONLY, AudioInfo.HEADER_SIZE,
@@ -93,19 +94,24 @@ public class WavFileLoader {
             //Otherwise use visualization.vis
             } else{
                 audioVisFile = new File(AudioInfo.pathToVisFile, "visualization.vis");
+                Logger.i(WavFileLoader.class.toString(), "Using the default visualization file");
             }
             //If the visualization file exists, map it to memory
             if(audioVisFile.exists()) {
                 RandomAccessFile rafCached = new RandomAccessFile(audioVisFile, "r");
                 FileChannel fcCached = rafCached.getChannel();
                 preprocessedBuffer = fcCached.map(FileChannel.MapMode.READ_ONLY, 0, rafCached.length());
+                Logger.i(WavFileLoader.class.toString(), "Found a matching visualization file: "
+                        + audioVisFile.getPath());
             //otherwise spawn a thread to generate the vis file file
             } else {
                 preprocessedBuffer = null;
                 Thread writeVisFile = new Thread(new Runnable() {
                     @Override
                     public void run() {
+                        Logger.w(WavFileLoader.class.toString(), "Could not find a matching vis file, creating...");
                         generateTempFile(loadedFilename);
+                        Logger.w(WavFileLoader.class.toString(), "Finished creating a vis file");
                         threadFinished = true;
                     }
                 });
@@ -123,7 +129,6 @@ public class WavFileLoader {
     private void generateTempFile(String loadedFilename){
         try {
             audioVisFile  = new File(AudioInfo.pathToVisFile + loadedFilename.substring(loadedFilename.lastIndexOf('/'), loadedFilename.lastIndexOf('.')) + ".vis");
-            System.out.println("loaded filename is " + audioVisFile.getAbsolutePath());
             FileOutputStream temp = new FileOutputStream(audioVisFile);
             int increment = (int)Math.floor((AudioInfo.SAMPLERATE * AudioInfo.COMPRESSED_SECONDS_ON_SCREEN)/screenWidth);
             increment = (increment % 2 == 0)? increment : increment+1;


### PR DESCRIPTION
Waveform was not drawing due to the scaling in getDataToDraw being taken
from WavFileWriter; which doesn't work if the file was loaded.

TODO: change the scaling to be db based

Removed the locking around draws, shouldn't be necessary when draws only
happen when one completes. if there's an issue, then use synchronized
anyway.