### PR TITLE
Bugfix: reset chapter chunk and verse after book

### DIFF
--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/SettingsPage/BookActivity.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/SettingsPage/BookActivity.java
@@ -82,6 +82,9 @@ public class BookActivity extends AppCompatActivity implements BookListFragment.
     public void onItemClick(Book targetBook) {
         SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
         pref.edit().putString(Settings.KEY_PREF_BOOK, targetBook.getSlug()).commit();
+        pref.edit().putString(Settings.KEY_PREF_CHAPTER, "1").commit();
+        pref.edit().putString(Settings.KEY_PREF_CHUNK, "1").commit();
+        pref.edit().putString(Settings.KEY_PREF_VERSE, "1").commit();
         Settings.updateFilename(this);
         this.finish();
     }

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/SettingsPage/SettingsFragment.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/SettingsPage/SettingsFragment.java
@@ -131,6 +131,12 @@ public class SettingsFragment extends PreferenceFragment  implements SharedPrefe
         //Doing this because the sharedPreferenceChanged method is not called from the language select activity
         findPreference(Settings.KEY_PREF_LANG_SRC).setSummary(sharedPref.getString(Settings.KEY_PREF_LANG_SRC, ""));
         findPreference(Settings.KEY_PREF_LANG).setSummary(sharedPref.getString(Settings.KEY_PREF_LANG, ""));
+
+        //if book was changed, need to update these...
+        findPreference(Settings.KEY_PREF_CHAPTER).setSummary(sharedPref.getString(Settings.KEY_PREF_CHAPTER, "1"));
+        findPreference(Settings.KEY_PREF_CHUNK).setSummary(sharedPref.getString(Settings.KEY_PREF_CHUNK, "1"));
+        findPreference(Settings.KEY_PREF_VERSE).setSummary(sharedPref.getString(Settings.KEY_PREF_VERSE, "1"));
+
         String uristring = sharedPref.getString(Settings.KEY_PREF_SRC_LOC, "");
         Uri dir = Uri.parse(uristring);
         if(dir != null) {


### PR DESCRIPTION
After selecting a book, the chapter, chunk, and verse need to default
back to one to prevent the possibility of trying to allow (and
ultimately access) an invalid index when switching from (ie) a high
chapter book to a lower one.