### PR TITLE
Bugfix: minimap using same width

### DIFF
--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/AudioFileAccessor.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/AudioFileAccessor.java
@@ -101,6 +101,7 @@ public class AudioFileAccessor {
         return locAndTime;
     }
 
+    //deprecated
     public int indicesInAPixelMinimap(){
         //get the number of milliseconds in a pixel, map it to an absolute index, then convert to relative
         double fileInc = Math.round((AudioInfo.SAMPLERATE * AudioInfo.COMPRESSED_SECONDS_ON_SCREEN) / (double)AudioInfo.SCREEN_WIDTH ) * 2;
@@ -137,26 +138,26 @@ public class AudioFileAccessor {
     }
 
     //used for minimap
-    public static double uncompressedIncrement(double adjustedDuration){
-        double increment = (((AudioInfo.SAMPLERATE * adjustedDuration)/(double)1000)/ (double)AudioInfo.SCREEN_WIDTH) * 2;
+    public static double uncompressedIncrement(double adjustedDuration, double screenWidth){
+        double increment = (((AudioInfo.SAMPLERATE * adjustedDuration)/(double)1000)/ screenWidth) * 2;
         //increment = (increment % 2 == 0)? increment : increment+1;
         return increment;
     }
 
     //used for minimap
-    public static double compressedIncrement(double adjustedDuration){
-        double increment = (uncompressedIncrement(adjustedDuration) / 50.f);
+    public static double compressedIncrement(double adjustedDuration, double screenWidth){
+        double increment = (uncompressedIncrement(adjustedDuration, screenWidth) / 50.f);
         //increment = (increment % 2 == 0)? increment : increment+1;
         return increment;
     }
 
     //FIXME: rounding will compound error in long files, resulting in pixels being off
     //used for minimap- this is why the duration matters
-    public static double getIncrement(double numSecondsOnScreen, boolean useCmp, double adjustedDuration){
+    public static double getIncrement(double numSecondsOnScreen, boolean useCmp, double adjustedDuration, double screenWidth){
         if(useCmp){
-            return compressedIncrement(adjustedDuration);
+            return compressedIncrement(adjustedDuration, screenWidth);
         } else {
-            return uncompressedIncrement(adjustedDuration);
+            return uncompressedIncrement(adjustedDuration, screenWidth);
         }
     }
 }

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/UIDataManager.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/UIDataManager.java
@@ -185,7 +185,7 @@ public class UIDataManager {
         Logger.w(UIDataManager.class.toString(), "Cutting from " + start + " to " + end);
         SectionMarkers.clearMarkers(this);
         Logger.w(this.toString(), "Reinitializing minimap");
-        minimap.init(wavVis.getMinimap(minimap.getHeight()));
+        minimap.init(wavVis.getMinimap(minimap.getHeight(), minimap.getWidth()));
         minimap.setAudioLength(mPlayer.getDuration() - mCutOp.getSizeCut());
         Logger.w(this.toString(), "Updating UI after cut");
         setDurationView();
@@ -257,8 +257,8 @@ public class UIDataManager {
         Logger.w(UIDataManager.class.toString(), "Loaded file duration in ms is: " + mPlayer.getDuration());
         minimap.setAudioLength(mPlayer.getDuration());
         Logger.w(this.toString(), "Setting up visualizer");
-        wavVis = new WavVisualizer(this, buffer, preprocessedBuffer, mainWave.getWidth(), mainWave.getHeight(), mCutOp);
-        minimap.init(wavVis.getMinimap(minimap.getHeight()));
+        wavVis = new WavVisualizer(this, buffer, preprocessedBuffer, mainWave.getWidth(), mainWave.getHeight(), minimap.getWidth(), mCutOp);
+        minimap.init(wavVis.getMinimap(minimap.getHeight(), minimap.getWidth()));
 //        wavVis = new WavVisualizer(buffer, preprocessedBuffer, mainWave.getMeasuredWidth(), mainWave.getMeasuredHeight());
         durationView = (TextView)ctx.findViewById(R.id.durationView);
         setDurationView();
@@ -383,7 +383,7 @@ public class UIDataManager {
         Logger.w(this.toString(), "Popping off last cut");
         mCutOp.undo();
         Logger.w(this.toString(), "Recomputing minimap");
-        minimap.init(wavVis.getMinimap(minimap.getHeight()));
+        minimap.init(wavVis.getMinimap(minimap.getHeight(), minimap.getWidth()));
         minimap.setAudioLength(mPlayer.getDuration() - mCutOp.getSizeCut());
         updateUI();
     }

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/WavVisualizer.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/AudioVisualization/WavVisualizer.java
@@ -22,7 +22,7 @@ public class WavVisualizer {
     AudioFileAccessor mAccessor;
     UIDataManager mManager;
 
-    public WavVisualizer(UIDataManager manager, MappedByteBuffer buffer, MappedByteBuffer compressed, int screenWidth, int screenHeight, CutOp cut) {
+    public WavVisualizer(UIDataManager manager, MappedByteBuffer buffer, MappedByteBuffer compressed, int screenWidth, int screenHeight, int minimapWidth, CutOp cut) {
         this.buffer = buffer;
         mScreenHeight = screenHeight;
         mScreenWidth = screenWidth;
@@ -32,7 +32,7 @@ public class WavVisualizer {
         mSamples = new float[screenWidth*8];
         mManager = manager;
         mAccessor = new AudioFileAccessor(compressed, buffer, cut, manager);
-        mMinimap = new float[AudioInfo.SCREEN_WIDTH * 4];
+        mMinimap = new float[minimapWidth * 4];
     }
 
     public void enableCompressedFileNextDraw(MappedByteBuffer compressed){
@@ -42,14 +42,14 @@ public class WavVisualizer {
         mCanSwitch = true;
     }
 
-    public float[] getMinimap(int minimapHeight){
+    public float[] getMinimap(int minimapHeight, int minimapWidth){
         //selects the proper buffer to use
         boolean useCompressed = mCanSwitch && mNumSecondsOnScreen > AudioInfo.COMPRESSED_SECONDS_ON_SCREEN;
         mAccessor.switchBuffers(useCompressed);
 
         int pos = 0;
         int index = 0;
-        double incrementTemp = mAccessor.getIncrement(mManager.getAdjustedDuration()/(double)1000, useCompressed, mManager.getAdjustedDuration());
+        double incrementTemp = mAccessor.getIncrement(mManager.getAdjustedDuration()/(double)1000, useCompressed, mManager.getAdjustedDuration(), minimapWidth);
         double leftover = incrementTemp - (int)Math.floor(incrementTemp);
         double count = 0;
         int increment = (int)Math.floor(incrementTemp);
@@ -57,7 +57,7 @@ public class WavVisualizer {
             increment*=2;
         }
         boolean leapedInc = false;
-        for(int i = 0; i < AudioInfo.SCREEN_WIDTH; i++){
+        for(int i = 0; i < minimapWidth; i++){
             double max = Double.MIN_VALUE;
             double min = Double.MAX_VALUE;
             if(count > 1){


### PR DESCRIPTION
some methods expected that the minimap had the same width as the main
canvas, which is no longer the case. Generating the minimap content now
uses the proper width.