### PR TITLE
Jbs bugfix 607

### DIFF
--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFile.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFile.java
@@ -30,7 +30,6 @@ import wycliffeassociates.recordingapp.Reporting.Logger;
  */
 public class WavFile implements Parcelable {
 
-    //public interface WavConstants {
     public static final int SAMPLERATE = 44100;
     public static final int CHANNEL_TYPE = AudioFormat.CHANNEL_IN_MONO;
     public static final int NUM_CHANNELS = 1;
@@ -40,7 +39,6 @@ public class WavFile implements Parcelable {
     public static final int SIZE_OF_SHORT = 2;
     public static final int AMPLITUDE_RANGE = 32767;
     public static final int BPP = 16;
-    //}
 
     File mFile;
     Metadata mMetadata;

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFile.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFile.java
@@ -140,7 +140,7 @@ public class WavFile implements Parcelable {
             try {
                 raf.close();
             } catch (IOException e) {
-                Logger.e(this.toString(), "IOException thrown in WavFile trying to close random access file", e);
+                Logger.e(this.toString(), "IOException while closing stream", e);
                 e.printStackTrace();
             }
         }
@@ -229,7 +229,7 @@ public class WavFile implements Parcelable {
                     bos.close();
                     fos.close();
                 } catch (IOException e) {
-                    Logger.e(this.toString(), "IOexception trying to close WavFile in initialize header", e);
+                    Logger.e(this.toString(), "IOException while closing streams", e);
                     e.printStackTrace();
                 }
             }
@@ -279,7 +279,7 @@ public class WavFile implements Parcelable {
                 bos.close();
                 fos.close();
             } catch (IOException e) {
-                Logger.e(this.toString(), "Could not close streams in pcmToWav", e);
+                Logger.e(this.toString(), "IOException while closing streams", e);
                 e.printStackTrace();
             }
         }
@@ -429,7 +429,7 @@ public class WavFile implements Parcelable {
             try {
                 fileAccessor.close();
             } catch (IOException e) {
-                Logger.e(this.toString(), "IOException closing stream overwriting header", e);
+                Logger.e(this.toString(), "IOException while closing streams", e);
                 e.printStackTrace();
             }
         }
@@ -460,7 +460,7 @@ public class WavFile implements Parcelable {
                 try {
                     raf.close();
                 } catch (IOException e) {
-                    Logger.e(this.toString(), "IOException closing stream", e);
+                    Logger.e(this.toString(), "IOException while closing stream", e);
                     e.printStackTrace();
                 }
             }
@@ -498,7 +498,7 @@ public class WavFile implements Parcelable {
                 try {
                     raf.close();
                 } catch (IOException e) {
-                    Logger.e(this.toString(), "IOException trying to close stream", e);
+                    Logger.e(this.toString(), "IOException while closing stream", e);
                     e.printStackTrace();
                 }
             }
@@ -658,7 +658,7 @@ public class WavFile implements Parcelable {
                         bis.close();
                         fis.close();
                     } catch (IOException e) {
-                        Logger.e("WavFile Compile Chapter", "IOException closing input streams after chapter compilation", e);
+                        Logger.e("WavFile Compile Chapter", "IOException while closing input streams", e);
                         e.printStackTrace();
                     }
                 }
@@ -676,7 +676,7 @@ public class WavFile implements Parcelable {
                 os.close();
                 chapterWav.overwriteHeaderData();
             } catch (IOException e) {
-                Logger.e("WavFile Compile Chapter", "IOException closing output streams after chapter compilation", e);
+                Logger.e("WavFile Compile Chapter", "IOException while closing output streams", e);
                 e.printStackTrace();
             }
         }
@@ -747,7 +747,7 @@ public class WavFile implements Parcelable {
                 fisBase.close();
                 fisInsert.close();
             } catch (IOException e) {
-                Logger.e("Insert", "IOException during stream close on insert", e);
+                Logger.e("Insert", "IOException while closing streams", e);
                 e.printStackTrace();
             }
         }

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFileWriter.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFileWriter.java
@@ -31,12 +31,8 @@ public class WavFileWriter extends Service {
     }
 
     @Override
-    public void onCreate() {
-
-    }
-
-    @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
+        super.onStartCommand(intent, flags, startId);
         final WavFile audioFile = intent.getParcelableExtra(KEY_WAV_FILE);
         String name = audioFile.getFile().getName();
         nameWithoutExtension = name.substring(0, name.lastIndexOf("."));

--- a/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFileWriter.java
+++ b/RecordingApp/app/src/main/java/wycliffeassociates/recordingapp/Recording/WavFileWriter.java
@@ -18,25 +18,25 @@ import wycliffeassociates.recordingapp.AudioInfo;
 import wycliffeassociates.recordingapp.Reporting.Logger;
 
 
-public class WavFileWriter extends Service{
+public class WavFileWriter extends Service {
 
     public static final String KEY_WAV_FILE = "wavfile";
     private String nameWithoutExtension = null;
     public static int largest = 0;
 
-    public static Intent getIntent(Context ctx, WavFile wavFile){
+    public static Intent getIntent(Context ctx, WavFile wavFile) {
         Intent intent = new Intent(ctx, WavFileWriter.class);
         intent.putExtra(KEY_WAV_FILE, wavFile);
         return intent;
     }
 
     @Override
-    public void onCreate(){
+    public void onCreate() {
 
     }
 
     @Override
-    public int onStartCommand(Intent intent, int flags, int startId){
+    public int onStartCommand(Intent intent, int flags, int startId) {
         final WavFile audioFile = intent.getParcelableExtra(KEY_WAV_FILE);
         String name = audioFile.getFile().getName();
         nameWithoutExtension = name.substring(0, name.lastIndexOf("."));
@@ -44,20 +44,19 @@ public class WavFileWriter extends Service{
             @Override
             public void run() {
                 boolean stopped = false;
+                FileOutputStream rawAudio = null;
                 try {
                     //WARNING DO NOT USE BUFFERED OUTPUT HERE, WILL CAUSE END LINE TO BE OFF IN PLAYBACK
-                    FileOutputStream rawAudio = new FileOutputStream(audioFile.getFile(), true);
-                    while(!stopped){
+                    rawAudio = new FileOutputStream(audioFile.getFile(), true);
+                    while (!stopped) {
                         RecordingMessage message = RecordingQueues.writingQueue.take();
-                        if(message.isStopped()){
+                        if (message.isStopped()) {
                             Logger.w(this.toString(), "raw audio thread received a stop message");
                             stopped = true;
-                        }
-                        else {
-                            if(!message.isPaused()) {
+                        } else {
+                            if (!message.isPaused()) {
                                 rawAudio.write(message.getData());
-                            }
-                            else {
+                            } else {
                                 Logger.w(this.toString(), "raw audio thread received a pause message");
                             }
                         }
@@ -75,7 +74,7 @@ public class WavFileWriter extends Service{
                 } catch (InterruptedException e) {
                     Logger.e(this.toString(), "Interrupted Exception in writing queue", e);
                     e.printStackTrace();
-                } catch (IOException e ) {
+                } catch (IOException e) {
                     Logger.e(this.toString(), "IO Exception in writing queue", e);
                     e.printStackTrace();
                 } catch (JSONException e) {
@@ -84,8 +83,14 @@ public class WavFileWriter extends Service{
                 } finally {
                     try {
                         RecordingQueues.doneWriting.put(new Boolean(true));
+                        if (rawAudio != null) {
+                            rawAudio.close();
+                        }
                     } catch (InterruptedException e) {
                         Logger.e(this.toString(), "InterruptedException in finally of writing queue", e);
+                        e.printStackTrace();
+                    } catch (IOException e) {
+                        Logger.e(this.toString(), "IOException while closing the file", e);
                         e.printStackTrace();
                     }
                 }
@@ -101,21 +106,21 @@ public class WavFileWriter extends Service{
                 boolean stoppedRecording = false;
                 ArrayList<Byte> byteArrayList = new ArrayList<>();
                 try {
-                    File dir = new File(AudioInfo.fileDir+"/Visualization");
-                    if(!dir.exists()){
+                    File dir = new File(AudioInfo.fileDir + "/Visualization");
+                    if (!dir.exists()) {
                         dir.mkdirs();
                     }
-                    File file = new File(AudioInfo.pathToVisFile + nameWithoutExtension +".vis");
-                    if(!file.exists()){
+                    File file = new File(AudioInfo.pathToVisFile + nameWithoutExtension + ".vis");
+                    if (!file.exists()) {
                         file.getParentFile().mkdirs();
                         file.createNewFile();
                         Logger.w(this.toString(), "created a new vis file");
                     }
                     //WARNING DO NOT USE BUFFERED OUTPUT HERE, WILL CAUSE END LINE TO BE OFF IN PLAYBACK
                     FileOutputStream compressedFile = new FileOutputStream(file);
-                    while(!stopped){
+                    while (!stopped) {
                         RecordingMessage message = RecordingQueues.compressionQueue.take();
-                        if(message.isStopped()){
+                        if (message.isStopped()) {
                             Logger.w(this.toString(), "Compression thread received a stop message");
                             stopped = true;
                             stoppedRecording = true;
@@ -123,18 +128,16 @@ public class WavFileWriter extends Service{
                             writeDataReceivedSoFar(compressedFile, byteArrayList, increment, stoppedRecording);
                             compressedFile.close();
                             Logger.w(this.toString(), "Compression thread closed file");
-                        }
-                        else {
-                            if (!message.isPaused()){
+                        } else {
+                            if (!message.isPaused()) {
                                 byte[] dataFromQueue = message.getData();
-                                for(byte x : dataFromQueue){
+                                for (byte x : dataFromQueue) {
                                     byteArrayList.add(new Byte(x));
                                 }
-                                if(byteArrayList.size() >= increment) {
+                                if (byteArrayList.size() >= increment) {
                                     writeDataReceivedSoFar(compressedFile, byteArrayList, increment, stoppedRecording);
                                 }
-                            }
-                            else{
+                            } else {
                                 Logger.w(this.toString(), "Compression thread received a pause message");
                             }
                         }
@@ -148,7 +151,7 @@ public class WavFileWriter extends Service{
                 } catch (InterruptedException e) {
                     Logger.e(this.toString(), "Interrupted Exception in compression queue", e);
                     e.printStackTrace();
-                } catch (IOException e ) {
+                } catch (IOException e) {
                     Logger.e(this.toString(), "IO Exception in compression queue", e);
                     e.printStackTrace();
                 } finally {
@@ -169,11 +172,11 @@ public class WavFileWriter extends Service{
 
     private void writeDataReceivedSoFar(FileOutputStream compressedFile, ArrayList<Byte> list, int increment, boolean stoppedRecording) throws IOException {
         byte[] data = new byte[increment];
-        byte[] minAndMax = new byte[2*AudioInfo.SIZE_OF_SHORT];
+        byte[] minAndMax = new byte[2 * AudioInfo.SIZE_OF_SHORT];
         //while there is more data in the arraylist than one increment
-        while(list.size() >= increment){
+        while (list.size() >= increment) {
             //remove that data and put it in an array for min/max computation
-            for(int i = 0; i < increment; i++){
+            for (int i = 0; i < increment; i++) {
                 data[i] = list.remove(0);
             }
             //write the min/max to the minAndMax array
@@ -183,10 +186,10 @@ public class WavFileWriter extends Service{
 
         }
         //if the recording was stopped and there is less data than a full increment, grab the remaining data
-        if(stoppedRecording){
+        if (stoppedRecording) {
             System.out.println("Stopped recording, writing some remaining data");
             byte[] remaining = new byte[list.size()];
-            for(int i = 0; i < list.size(); i++){
+            for (int i = 0; i < list.size(); i++) {
                 remaining[i] = list.remove(0);
             }
             getMinAndMaxFromArray(remaining, minAndMax);
@@ -199,42 +202,44 @@ public class WavFileWriter extends Service{
         return null;
     }
 
-    private void getMinAndMaxFromArray(byte[] data, byte[] minAndMax){
-        if(data.length < 4){ return; }
+    private void getMinAndMaxFromArray(byte[] data, byte[] minAndMax) {
+        if (data.length < 4) {
+            return;
+        }
         int max = Integer.MIN_VALUE;
         int min = Integer.MAX_VALUE;
         int minIdx = 0;
         int maxIdx = 0;
-        for(int j = 0; j < data.length; j+=AudioInfo.SIZE_OF_SHORT){
-            if((j+1) < data.length) {
+        for (int j = 0; j < data.length; j += AudioInfo.SIZE_OF_SHORT) {
+            if ((j + 1) < data.length) {
                 byte low = data[j];
                 byte hi = data[j + 1];
                 short value = (short) (((hi << 8) & 0x0000FF00) | (low & 0x000000FF));
-                if(max < value){
+                if (max < value) {
                     max = value;
                     maxIdx = j;
-                    if(value > largest){
+                    if (value > largest) {
                         largest = value;
                     }
                 }
-                if(min > value) {
+                if (min > value) {
                     min = value;
                     minIdx = j;
                 }
             }
         }
         minAndMax[0] = data[minIdx];
-        minAndMax[1] = data[minIdx+1];
+        minAndMax[1] = data[minIdx + 1];
         minAndMax[2] = data[maxIdx];
-        minAndMax[3] = data[maxIdx+1];
+        minAndMax[3] = data[maxIdx + 1];
 
     }
 
-    public static void overwriteHeaderData(String filepath, long totalAudioLength, int metadataLength){
+    public static void overwriteHeaderData(String filepath, long totalAudioLength, int metadataLength) {
         overwriteHeaderData(new File(filepath), totalAudioLength, metadataLength);
     }
 
-    public static void overwriteHeaderData(File filepath, long totalAudioLen, int metadataLength){
+    public static void overwriteHeaderData(File filepath, long totalAudioLen, int metadataLength) {
         //long totalAudioLen = totalDataLen - AudioInfo.HEADER_SIZE; //While the header is 44 bytes, 8 consist of the data subchunk header
         long totalDataLen = totalAudioLen + metadataLength - 8; //this subtracts out the data subchunk header
         try {
@@ -259,7 +264,7 @@ public class WavFileWriter extends Service{
             header[12] = 'f'; // fmt  chunk
             header[13] = 'm';
             header[14] = 't';
-            header[15] = ' ' ;
+            header[15] = ' ';
             header[16] = 16; // 4 bytes: size of fmt chunk
             header[17] = 0;
             header[18] = 0;
@@ -293,7 +298,7 @@ public class WavFileWriter extends Service{
         } catch (FileNotFoundException e) {
             Logger.e("WavFileWriter", "File Not Found Exception in writing header", e);
             e.printStackTrace();
-        } catch (IOException e){
+        } catch (IOException e) {
             Logger.e("WavFileWriter", "IO Exception in writing header", e);
             e.printStackTrace();
         }


### PR DESCRIPTION
This PR is mostly just closing streams in finally blocks and adding logging during exceptions.

Also took out an unused comment, an unused onCreate, and inserted a missing call to a super in an overriden method.

Note, there are a lot of bare numbers that should be enums in the WavFile class; see issue #626 