### PR TITLE
corrected check for section markers

### DIFF
--- a/translationRecorder/app/build.gradle
+++ b/translationRecorder/app/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 22
         versionCode 4
-        versionName "1.0.0- Closed Beta Jan 24"
+        versionName "1.0.0- Closed Beta Jan 24b"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/translationRecorder/app/src/main/java/org/wycliffeassociates/translationrecorder/Playback/interfaces/MarkerMediator.java
+++ b/translationRecorder/app/src/main/java/org/wycliffeassociates/translationrecorder/Playback/interfaces/MarkerMediator.java
@@ -32,4 +32,5 @@ public interface MarkerMediator {
     boolean hasVersesRemaining();
     int numVersesRemaining();
     int numVerseMarkersPlaced();
+    boolean hasSectionMarkers();
 }

--- a/translationRecorder/app/src/main/java/org/wycliffeassociates/translationrecorder/Playback/markers/MarkerHolder.java
+++ b/translationRecorder/app/src/main/java/org/wycliffeassociates/translationrecorder/Playback/markers/MarkerHolder.java
@@ -213,4 +213,8 @@ public class MarkerHolder implements MarkerMediator {
         }
         return markers;
     }
+
+    public boolean hasSectionMarkers(){
+        return mMarkers.containsKey(START_MARKER_ID) || mMarkers.containsKey(END_MARKER_ID);
+    }
 }


### PR DESCRIPTION
Was checking if the mark and limit had changed; but this check was wrong
if the limit was set to the end of the file.

Now checking with the markerholder if it was actually set.

Also, re-posting the call to swap in the visualization file via a
handler, because the call can theoretically happen before the visualizer
has been created from the VTO callback.